### PR TITLE
TemplateRenderer::JSONizer add require

### DIFF
--- a/lib/jb/action_view_monkeys.rb
+++ b/lib/jb/action_view_monkeys.rb
@@ -1,3 +1,5 @@
+require 'multi_json'
+
 module Jb
   module PartialRenderer
     module JbTemplateDetector


### PR DESCRIPTION
mitigates a NameError exception "uninitialized constant Jb::TemplateRenderer::JSONizer::MultiJson" when rendering a collection (Rails 5.0.0.rc2)