### PR TITLE
Add support for Rails API-mode

### DIFF
--- a/lib/jb/railtie.rb
+++ b/lib/jb/railtie.rb
@@ -9,6 +9,21 @@ module Jb
       end
     end
 
+    if Rails::VERSION::MAJOR >= 5
+      module ::ActionController
+        module ApiRendering
+          include ActionView::Rendering
+        end
+      end
+
+      ActiveSupport.on_load :action_controller do
+        if self == ActionController::API
+          include ActionController::Helpers
+          include ActionController::ImplicitRender
+        end
+      end
+    end
+
     generators do |app|
       Rails::Generators.configure! app.config.generators
       Rails::Generators.hidden_namespaces.uniq!


### PR DESCRIPTION
By default, in Rails API mode, which was introduces since Rails 5, `jb` views don't work.

By inspecting `jbuilder`s codebase, I noticed that some additional initialization code is required for templates to work, so here is a fix.
Copied from [railtie.rb](https://github.com/rails/jbuilder/blob/003a369f7432c7173d00c453484ae11f1c952a15/lib/jbuilder/railtie.rb#L12)