### PR TITLE
Add note about using render without a partial path

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,10 @@ It's also possible to render collections of partials:
 
 ```ruby
 render partial: 'posts/post', collection: @posts, as: :post
-
-# or
-
-render @post.comments
 ```
+
+> NOTE: Don't use `render @post.comments` because if the collection is empty,
+`render` will return `nil` instead of an empty array.
 
 You can pass any objects into partial templates with or without `:locals` option.
 


### PR DESCRIPTION
When the collection is empty, the partial path is `nil`
(https://github.com/rails/rails/blob/master/actionview/lib/action_view/renderer/partial_renderer.rb#L384..L385),
and the renderer cannot find a template that can be monkey-patched
(https://github.com/rails/rails/blob/master/actionview/lib/action_view/renderer/partial_renderer.rb#L418).

This is expected behaviour from ActionView, so I think we should just
update the README to make it clear.

Related to #8, #11.