### PR TITLE
Remove mention that `Hash#compact` belongs to AS

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ render 'sub_template', user: user
 
 You can of course include Ruby `nil` as a Hash value if you want. That would become `null` in the JSON.
 
-To prevent Jb from including null values in the output, Active Support provides `Hash#compact!` method for you:
+You can use `Hash#compact`/`!` method to prevent including `null` values in the output:
 
 ```ruby
 {foo: nil, bar: 'bar'}.compact


### PR DESCRIPTION
It used to be in AS. Since Ruby 2.4 it belongs to Ruby
https://github.com/ruby/ruby/blob/ruby_2_4/NEWS