### PR TITLE
another rails 6 fix

### DIFF
--- a/lib/jb/action_view_monkeys.rb
+++ b/lib/jb/action_view_monkeys.rb
@@ -6,8 +6,8 @@ module Jb
   module PartialRenderer
     module JbTemplateDetector
       # A monkey-patch to inject StrongArray module to Jb partial renderer
-      private def find_partial
-        template = super
+      private def find_partial(*args)
+        template = super(*args)
         extend RenderCollectionExtension if template && (template.handler == Jb::Handler)
         template
       end


### PR DESCRIPTION
I've got this while rendering partials in .html.erb.

the call was from here
https://github.com/rails/rails/blob/master/actionview/lib/action_view/renderer/partial_renderer.rb#L308

trace
```
ActionView::Template::Error: wrong number of arguments (given 2, expected 0)
       from /usr/local/bundle/gems/jb-0.6.1/lib/jb/action_view_monkeys.rb:9:in `find_partial'
       from /usr/local/bundle/gems/actionview-6.0.0.beta2/lib/action_view/renderer/partial_renderer.rb:308:in `render'
```