### PR TITLE
add selenium-webdriber to dependency for test

### DIFF
--- a/jb.gemspec
+++ b/jb.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'action_args'
   spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'selenium-webdriver'
 end


### PR DESCRIPTION
I got ` cannot load such file -- selenium/webdriver (LoadError)` when execute `rake test` after `git clone` and `bundle install`