### PR TITLE
change response json format of time to iso8601

### DIFF
--- a/lib/jb/action_view_monkeys.rb
+++ b/lib/jb/action_view_monkeys.rb
@@ -7,7 +7,7 @@ module Jb
     module JSONizer
       def render_template(_view, template, *)
         rendered_template = super
-        rendered_template.instance_variable_set :@body, rendered_template.body.to_json if template.respond_to?(:handler) && (template.handler == Jb::Handler)
+        rendered_template.instance_variable_set :@body, rendered_template.body.as_json.to_json if template.respond_to?(:handler) && (template.handler == Jb::Handler)
         rendered_template
       end
     end


### PR DESCRIPTION
## version

- ruby 3.0.2
- rails 6.0.3.7
- jb 0.8.0

## problem

When I upgraded ruby version from 2.7.2 to 3.0.2, response json format of time was changed.

### before(ruby 2.7.2)

```ruby
> response.body
"{\"updatedAt\":\"2021-07-31T15:22:52.648+09:00\"}"
```

### after(ruby 3.0.2)

```ruby
> response.body
"{\"updatedAt\":\"2021-07-31 15:20:29 +0900\"}"
```

## solution

I run `ActiveSupport::TimeWithZone#as_json` before `#to_json`.
