### PR TITLE
Fix typo in action_view_monkeys.rb & action_view_legacy_monkeys.rb

### DIFF
--- a/lib/jb/action_view_legacy_monkeys.rb
+++ b/lib/jb/action_view_legacy_monkeys.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# Mokey-patches for Action View 4 and 5
+# Monkey-patches for Action View 4 and 5
 
 module Jb
   module PartialRenderer

--- a/lib/jb/action_view_monkeys.rb
+++ b/lib/jb/action_view_monkeys.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# Mokey-patches for Action View 6+
+# Monkey-patches for Action View 6+
 
 module Jb
   # A monkey-patch that converts non-partial result to a JSON String


### PR DESCRIPTION
Found typos in action_view_monkeys.rb & action_view_legacy_monkeys.rb and fixed them.

`s/Mokey/Monkey`